### PR TITLE
Modernize template-related settings

### DIFF
--- a/enhydris/settings/base.py
+++ b/enhydris/settings/base.py
@@ -43,17 +43,25 @@ MIDDLEWARE_CLASSES = (
 
 APPEND_SLASH = True
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
-    'django.contrib.auth.context_processors.auth',
-    'django.contrib.messages.context_processors.messages',
-    'enhydris.hcore.context_processors.registration',
-    'enhydris.hcore.context_processors.map',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.core.context_processors.debug',
+                'django.core.context_processors.i18n',
+                'django.core.context_processors.media',
+                'django.core.context_processors.static',
+                'django.core.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'enhydris.hcore.context_processors.registration',
+                'enhydris.hcore.context_processors.map',
+            ],
+        },
+    },
+]
 
 AUTH_PROFILE_MODULE = 'hcore.UserProfile'
 LOGIN_REDIRECT_URL = '/'


### PR DESCRIPTION
Django 1.8 deprecates the old way of specifying template settings; we
have changed settings to use the new way.