### PR TITLE
Fix CSV view

### DIFF
--- a/enhydris/hcore/tests/test_views.py
+++ b/enhydris/hcore/tests/test_views.py
@@ -9,6 +9,7 @@ import textwrap
 import time
 from unittest import skipIf, skipUnless
 from urllib.parse import urlencode
+from zipfile import ZipFile
 
 import django
 from django.conf import settings
@@ -81,6 +82,14 @@ class StationsTestCase(TestCase):
         self.assertContains(
             response, '<a href="?sort=-name&amp;sort=name">Name&nbsp;↓</a>',
             html=True)
+
+    def test_station_list_csv(self):
+        response = self.client.get('/?format=csv')
+        with tempfile.TemporaryFile() as t:
+            t.write(response.content)
+            with ZipFile(t) as f:
+                stations_csv = f.open('stations.csv').read().decode()
+                self.assertTrue('Agios Athanasios' in stations_csv)
 
     def test_station_cannot_be_deleted_with_get(self):
         komboti = Station.objects.get(name='Komboti')

--- a/enhydris/hcore/tests/test_views.py
+++ b/enhydris/hcore/tests/test_views.py
@@ -1353,7 +1353,7 @@ class ResetPasswordTestCase(TestCase):
         self.assertEqual(len(django.core.mail.outbox), 1)
 
         # Get the link from the email
-        m = re.search('http://[^/]+(\S+)', django.core.mail.outbox[0].body)
+        m = re.search(r'http://[^/]+(\S+)', django.core.mail.outbox[0].body)
         reset_link = m.group(1)
 
         # Visit the link and submit the form

--- a/enhydris/hcore/views.py
+++ b/enhydris/hcore/views.py
@@ -188,9 +188,8 @@ def _prepare_csv(queryset):
     zipfile = ZipFile(zipfilename, 'w', ZIP_DEFLATED)
 
     stationsfilename = os.path.join(tempdir, 'stations.csv')
-    stationsfile = open(stationsfilename, 'w')
+    stationsfile = open(stationsfilename, 'w', encoding='utf-8-sig')
     try:
-        stationsfile.write(b'\xef\xbb\xbf')  # BOM
         csvwriter = csv.writer(stationsfile)
         csvwriter.writerow(_station_list_csv_headers)
         for station in queryset:
@@ -200,9 +199,8 @@ def _prepare_csv(queryset):
     zipfile.write(stationsfilename, 'stations.csv')
 
     instrumentsfilename = os.path.join(tempdir, 'instruments.csv')
-    instrumentsfile = open(instrumentsfilename, 'w')
+    instrumentsfile = open(instrumentsfilename, 'w', encoding='utf-8-sig')
     try:
-        instrumentsfile.write(b'\xef\xbb\xbf')  # BOM
         csvwriter = csv.writer(instrumentsfile)
         csvwriter.writerow(_instrument_list_csv_headers)
         for station in queryset:
@@ -213,9 +211,8 @@ def _prepare_csv(queryset):
     zipfile.write(instrumentsfilename, 'instruments.csv')
 
     timeseriesfilename = os.path.join(tempdir, 'timeseries.csv')
-    timeseriesfile = open(timeseriesfilename, 'w')
+    timeseriesfile = open(timeseriesfilename, 'w', encoding='utf-8-sig')
     try:
-        timeseriesfile.write(b'\xef\xbb\xbf')  # BOM
         csvwriter = csv.writer(timeseriesfile)
         csvwriter.writerow(_timeseries_list_csv_headers)
         for station in queryset:
@@ -479,7 +476,7 @@ class StationListView(StationListBaseView):
         # for some people (Hydroexigiantiki) who needed it.
         if request.GET.get("format", "").lower() == "csv":
             zipfilename = _prepare_csv(self.get_queryset())
-            response = HttpResponse(file(zipfilename, 'rb').read(),
+            response = HttpResponse(open(zipfilename, 'rb').read(),
                                     content_type='application/zip')
             response['Content-Disposition'] = 'attachment; filename=data.zip'
             response['Content-Length'] = str(os.path.getsize(zipfilename))


### PR DESCRIPTION
Enhydris has an undocumented CSV view that sends you a zip file with
stations, instruments and time series in CSV when you add ?format=csv to
a stations list URL. Apparently this has been broken since we moved to
Python 3.