### PR TITLE
Remove deletion of user profile from migrations (fixes #122)

### DIFF
--- a/enhydris/migrations/0004_delete_user_profile.py
+++ b/enhydris/migrations/0004_delete_user_profile.py
@@ -1,8 +1,0 @@
-from django.db import migrations
-
-
-class Migration(migrations.Migration):
-
-    dependencies = [("enhydris", "0003_user_name")]
-
-    operations = [migrations.DeleteModel(name="UserProfile")]

--- a/enhydris/migrations/0005_remove_gentity_generic_data.py
+++ b/enhydris/migrations/0005_remove_gentity_generic_data.py
@@ -18,7 +18,7 @@ def do_nothing(*args, **kwargs):
 
 class Migration(migrations.Migration):
 
-    dependencies = [("enhydris", "0004_delete_user_profile")]
+    dependencies = [("enhydris", "0003_user_name")]
 
     operations = [
         migrations.RunPython(check_that_generic_data_is_empty, do_nothing),

--- a/enhydris/models.py
+++ b/enhydris/models.py
@@ -715,3 +715,29 @@ class Timeseries(models.Model):
         self._check_integrity_of_offset_and_rounding_when_time_step_is_not_null()
         self._set_start_and_end_date()
         super(Timeseries, self).save(force_insert, force_update, *args, **kwargs)
+
+
+class UserProfile(models.Model):
+    """Unused model for backwards compatibility.
+
+    This model isn't being used. We need it so that Enhydris 3 and Enhydris 2.2 can
+    co-exist, using the same database. This is because, for some time, Enhydris 2.2
+    will be in production but Enhydris 3 will be running on the same database being
+    tested. When production is switched to use Enhydris 3 and 2.2 is pronounced dead,
+    this model should be removed.
+    """
+
+    user = models.OneToOneField(
+        User, on_delete=models.CASCADE, verbose_name=_("Username")
+    )
+    fname = models.CharField(_("First Name"), null=True, blank=True, max_length=30)
+    lname = models.CharField(_("Last Name"), null=True, blank=True, max_length=30)
+    address = models.CharField(_("Location"), null=True, blank=True, max_length=100)
+    organization = models.CharField(
+        _("Organization"), null=True, blank=True, max_length=100
+    )
+    email_is_public = models.BooleanField(default=False)
+
+    class Meta:
+        verbose_name = _("Profile")
+        verbose_name_plural = _("Profiles")


### PR DESCRIPTION
Enhydris 2 uses the user profile table, but Enhydris 3 does not. For a
while we will be running Enhydris 2 and Enhydris 3 from the same
database, so we don't want to delete the table yet in order to allow
Enhydris 2 to continue functioning without change in this respect.