### PR TITLE
Add optional admin link (fixes #155)

### DIFF
--- a/frontend/components/layout/NavBar.vue
+++ b/frontend/components/layout/NavBar.vue
@@ -28,6 +28,14 @@
           </a>
         </div>
         <div class="navbar-end">
+          <a
+            v-if="adminLink"
+            id="adminLink"
+            class="navbar-item"
+            :href="adminLink"
+          >
+            {{ $t("login") }}
+          </a>
           <LangPicker />
         </div>
       </div>
@@ -45,7 +53,8 @@ export default {
   },
   data() {
     return {
-      isOpen: false
+      isOpen: false,
+      adminLink: process.env.adminLink
     };
   },
   computed: {

--- a/frontend/locales/el.json
+++ b/frontend/locales/el.json
@@ -1,5 +1,6 @@
 {
   "language": "Γλώσσα",
+  "login": "Είσοδος",
   "language_picker": "Ελληνικά",
   "search": "Αναζήτηση",
   "reset": "Ανανέωση",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1,5 +1,6 @@
 {
   "language": "Language",
+  "login": "Login",
   "language_picker": "English",
   "search": "Search",
   "reset": "Reset",

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -4,6 +4,9 @@ import enTranslations from "./locales/en.json";
 import elTranslations from "./locales/el";
 
 module.exports = {
+  env: {
+    adminLink: ""
+  },
   head: {
     titleTemplate: `%s — Enhydris`,
     meta: [

--- a/frontend/tests/components/layout/NavBar.spec.js
+++ b/frontend/tests/components/layout/NavBar.spec.js
@@ -24,3 +24,25 @@ describe("NavBar with locale en", () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 });
+
+describe("NavBar with admin link", () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallowMount(NavBar, {
+      mocks: {
+        $t: msg => msg,
+        $i18n: { locale: "en" }
+      }
+    });
+  });
+
+  it("has admin link", () => {
+    wrapper.setData({ adminLink: "/admin/" });
+    expect(wrapper.find("#adminLink").element.text).toContain("login");
+  });
+
+  it("renders correctly", () => {
+    wrapper.setData({ adminLink: "/admin/" });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});

--- a/frontend/tests/components/layout/__snapshots__/NavBar.spec.js.snap
+++ b/frontend/tests/components/layout/__snapshots__/NavBar.spec.js.snap
@@ -1,5 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`NavBar with admin link renders correctly 1`] = `
+<div>
+  <nav
+    aria-label="main navigation"
+    class="navbar is-dark"
+    role="navigation"
+  >
+    <div
+      class="navbar-brand"
+    >
+      <a
+        aria-expanded="false"
+        aria-label="menu"
+        class="navbar-burger burger"
+        data-target="navbarBasicExample"
+        role="button"
+      >
+        <span
+          aria-hidden="true"
+        />
+         
+        <span
+          aria-hidden="true"
+        />
+         
+        <span
+          aria-hidden="true"
+        />
+      </a>
+    </div>
+     
+    <div
+      class="navbar-menu"
+    >
+      <div
+        class="navbar-start"
+      >
+        <a
+          class="navbar-item"
+          href=""
+          id="home"
+        >
+          
+          home
+        
+        </a>
+      </div>
+       
+      <div
+        class="navbar-end"
+      >
+        <a
+          class="navbar-item"
+          href="/admin/"
+          id="adminLink"
+        >
+          
+          login
+        
+        </a>
+         
+        <langpicker-stub />
+      </div>
+    </div>
+  </nav>
+</div>
+`;
+
 exports[`NavBar with locale en renders correctly 1`] = `
 <div>
   <nav
@@ -51,6 +119,8 @@ exports[`NavBar with locale en renders correctly 1`] = `
       <div
         class="navbar-end"
       >
+        <!---->
+         
         <langpicker-stub />
       </div>
     </div>


### PR DESCRIPTION
<img width="1257" alt="Screenshot 2019-04-18 19 17 46" src="https://user-images.githubusercontent.com/5064612/56375848-3bdecf00-620f-11e9-93e9-75841e5f3141.png">

After reading around a common practice to have configs in `nuxtjs.config` is using `env` propertly.
- https://github.com/nuxt/nuxt.js/issues/858
- https://nuxtjs.org/api/configuration-env/

In this PR an nuxtjs.config exist
```
  env: {
    adminLink: ""
  },
```

It not really needed as this can override using `.env` but it good to have it as  default value and remainder.  Maybe a more proper name for this 'adminLink' is more suitable.

