### PR TITLE
Downgrade to Django 2.1 (fixes #175)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Django>=2.2,<3
+# Don't use Django 2.2 until https://code.djangoproject.com/ticket/30459 is fixed
+Django>=2.1,<2.2
 djangorestframework>=3.9,<4
 gdal>=1.6
 simpletail>=0.1.2


### PR DESCRIPTION
We are hit by https://code.djangoproject.com/ticket/30459, so
downgrading to Django 2.1 until it's fixed.