### PR TITLE
Fix a typo in the `main-default.html` file (fix #351)

### DIFF
--- a/enhydris/templates/enhydris/timeseries_group_detail/main-default.html
+++ b/enhydris/templates/enhydris/timeseries_group_detail/main-default.html
@@ -22,7 +22,7 @@
       <div class="card-body">
         <div class="row">
           <div class="col-xs-12 col-sm-5">
-            {% if object.timeseries_set.exits %}
+            {% if object.timeseries_set.exists %}
               {% include "enhydris/timeseries_group_detail/chart.html" %}
             {% else %}
               <div class="message-no-data">


### PR DESCRIPTION
Closes #351 