### PR TITLE
Add `Arg` variable to `globals` in .eslintrc file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
         "google": "readonly",
         "moment": "readonly",
         "L": "readonly",
-        "ApexCharts": "readonly"
+        "ApexCharts": "readonly",
+        "Arg": "readonly"
     },
     "rules": {
         "prefer-arrow-callback": "off",

--- a/enhydris/static/js/enhydris.js
+++ b/enhydris/static/js/enhydris.js
@@ -38,7 +38,7 @@ enhydris.mapModule = (function namespace() {
   };
 
   const listStationsVisibleOnMap = function () {
-    const queryParams = Arg.all(); /* eslint no-undef: "off" */
+    const queryParams = Arg.all();
     queryParams.bbox = map.getBounds().toBBoxString();
     let queryString = '';
     Object.keys(queryParams).forEach((param) => {


### PR DESCRIPTION
Currently, a magic comment is used in the  enhydris.js file to instruct ESLint to ignore the `Arg` global variable. Instead, add the `Arg` variable to `globals` section in the .eslintrc file.
