### PR TITLE
Fix crash when getting data with start_date or end_date

### DIFF
--- a/enhydris/api/views.py
+++ b/enhydris/api/views.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import mimetypes
 import os
 from io import StringIO
@@ -13,7 +14,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
 import iso8601
-import pandas as pd
 from htimeseries import HTimeseries
 
 from enhydris import models
@@ -330,8 +330,8 @@ class TimeseriesViewSet(ModelViewSet):
             return None
 
     def _bring_date_within_system_limits(self, date):
-        if date.isoformat() < pd.Timestamp.min.isoformat():
-            date = pd.Timestamp.min
-        if date.isoformat() > pd.Timestamp.max.isoformat():
-            date = pd.Timestamp.max
+        if date.isoformat() < "1680-01-01T00:00":
+            date = dt.datetime(1680, 1, 1, 0, 0, tzinfo=date.tzinfo)
+        if date.isoformat() > "2260-01-01T00:00":
+            date = dt.datetime(2260, 1, 1, 0, 0, tzinfo=date.tzinfo)
         return date


### PR DESCRIPTION
When getting
/api/stations/xxxx/timeseriesgroups/xxx/timeseries/xxxx/data/ with the
query string ?start_date=X&end_date=Y, if the start date or end date
were outside the limits of pandas.Timestamp (i.e. earlier than roughly
1680 or later than roughly 2260), it was crashing.

**Checklist**:

* [ ] All tests are passing
* [ ] I have added any necessary documentation and/or release notes
* [ ] I have followed the [commit message guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#committing-and-commit-messages) and the ["before submitting a pull request" guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#before-submitting-a-pull-request)
* [ ] If I introduced (or abolished) any third-party library, I will write a short paragraph in this PR [according to the guidelines](https://wiki.antonischristofides.com/sops/production/development/third-party-libraries)
* [ ] I have removed all obsoleted code
