### PR TITLE
Don't crash when appending unordered overlapping time series (fixes #422)

### DIFF
--- a/enhydris/admin/station.py
+++ b/enhydris/admin/station.py
@@ -168,7 +168,7 @@ class TimeseriesInlineAdminForm(forms.ModelForm):
         return data_exists and submitted_data_exists and user_wants_to_append
 
     def _check_timeseries_for_appending(self, ahtimeseries):
-        if self.instance.end_date.replace(tzinfo=None) >= ahtimeseries.data.index[0]:
+        if self.instance.end_date.replace(tzinfo=None) >= ahtimeseries.data.index.min():
             raise forms.ValidationError(
                 _(
                     "Can't append; the first record of the time series to append is "

--- a/enhydris/tests/admin/test_station.py
+++ b/enhydris/tests/admin/test_station.py
@@ -466,6 +466,17 @@ class TimeseriesUploadInvalidFileTestCase(TestCase, TestTimeseriesFormMixin):
         self.assertFalse(self.form.is_valid())
 
 
+class TimeseriesUploadAppendWithOverlapTestCase(TestCase, TestTimeseriesFormMixin):
+    def setUp(self):
+        self._create_test_timeseries(data="2005-11-01 18:00,3,\n2019-01-01 00:30,25,\n")
+
+    def test_append_badly_ordered_file_that_overlaps(self):
+        self._create_timeseries_inline_admin_form(
+            "APPEND", b"2019-01-02 00:30,42,\n2019-01-01 00:30,42,\n"
+        )
+        self.assertFalse(self.form.is_valid())
+
+
 class TimeseriesInlineAdminFormProcessWithoutFileTestCase(
     TestCase, TestTimeseriesFormMixin
 ):


### PR DESCRIPTION
**Checklist**:

* [ ] All tests are passing
* [ ] I have added any necessary documentation and/or release notes
* [ ] I have followed the [commit message guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#committing-and-commit-messages) and the ["before submitting a pull request" guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#before-submitting-a-pull-request)
* [ ] If I introduced (or abolished) any third-party library, I will write a short paragraph in this PR [according to the guidelines](https://wiki.antonischristofides.com/sops/production/development/third-party-libraries)
* [ ] I have removed all obsoleted code
