### PR TITLE
Fix data_timezone when saving addupi telemetry

### DIFF
--- a/enhydris/telemetry/forms.py
+++ b/enhydris/telemetry/forms.py
@@ -37,7 +37,9 @@ class ConnectionDataForm(FormBase):
         if self.driver.hide_device_locator:
             self.fields["device_locator"].widget = forms.HiddenInput()
         if self.driver.hide_data_timezone:
-            self.fields["data_timezone"].widget = forms.HiddenInput()
+            self.fields["data_timezone"].widget = forms.HiddenInput(
+                attrs={"value": "UTC"}
+            )
             self.fields["data_timezone"].required = False
 
     def clean(self):

--- a/enhydris/telemetry/models.py
+++ b/enhydris/telemetry/models.py
@@ -7,7 +7,7 @@ from io import StringIO
 from traceback import print_tb
 
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db import models
+from django.db import IntegrityError, models
 from django.utils.translation import ugettext_lazy as _
 
 import iso8601
@@ -116,6 +116,14 @@ class Telemetry(models.Model):
             prev_timestamp = cur_timestamp
         result.seek(0)
         return result
+
+    def _check_data_timezone(self):
+        if self.data_timezone not in [choice[0] for choice in timezone_choices]:
+            raise IntegrityError(f"'{self.data_timezone}' is not a valid time zone")
+
+    def save(self, *args, **kwargs):
+        self._check_data_timezone()
+        super().save(*args, **kwargs)
 
 
 class Sensor(models.Model):

--- a/enhydris/telemetry/tests/test_forms.py
+++ b/enhydris/telemetry/tests/test_forms.py
@@ -118,6 +118,11 @@ class ConnectionDataFormHideStuffTestCase(TestCase):
         widget_class_name = form.fields["data_timezone"].widget.__class__.__name__
         self.assertEqual(widget_class_name, "HiddenInput")
 
+    def test_data_timezone_hidden_value(self):
+        TestTelemetryAPIClient.hide_data_timezone = True
+        form = ConnectionDataForm(*self.form_args, **self.form_kwargs)
+        self.assertEqual(form.fields["data_timezone"].widget.attrs["value"], "UTC")
+
     def test_data_timezone_not_hidden(self):
         TestTelemetryAPIClient.hide_data_timezone = False
         form = ConnectionDataForm(*self.form_args, **self.form_kwargs)

--- a/enhydris/telemetry/tests/test_models.py
+++ b/enhydris/telemetry/tests/test_models.py
@@ -7,6 +7,7 @@ from io import StringIO
 from unittest.mock import MagicMock, patch
 
 from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 from django.test import TestCase
 
 from freezegun import freeze_time
@@ -15,6 +16,19 @@ from model_mommy import mommy
 import enhydris
 from enhydris.models import Station, Timeseries, TimeseriesGroup
 from enhydris.telemetry.models import Telemetry, TelemetryLogMessage, fix_zone_name
+
+
+class TelemetryTestCase(TestCase):
+    def test_cannot_save_wrong_data_timezone(self):
+        with self.assertRaisesRegex(IntegrityError, "'' is not a valid time zone"):
+            Telemetry.objects.create(
+                station=mommy.make(Station),
+                type="meteoview2",
+                fetch_interval_minutes=10,
+                fetch_offset_minutes=2,
+                additional_config="{}",
+                data_timezone="",
+            )
 
 
 class TelemetryFetchValidatorsTestCase(TestCase):

--- a/enhydris/telemetry/tests/test_views/test_telemetry_wizard_view.py
+++ b/enhydris/telemetry/tests/test_views/test_telemetry_wizard_view.py
@@ -369,7 +369,6 @@ class SecondStepPostSuccessfulMixin(SecondStepPostMixin):
                     "data_timezone": "Europe/Athens",
                     "username": "someemail@email.com",
                     "password": "topsecret",
-                    "data_timezone": "Europe/Athens",
                 },
             )
 


### PR DESCRIPTION
When saving addupi telemetry, time zone was set to the empty string instead of "UTC", resulting in error when attempting to fetch the data.

**Checklist**:

* [ ] All tests are passing
* [ ] I have added any necessary documentation and/or release notes
* [ ] I have followed the [commit message guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#committing-and-commit-messages) and the ["before submitting a pull request" guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#before-submitting-a-pull-request)
* [ ] If I introduced (or abolished) any third-party library, I will write a short paragraph in this PR [according to the guidelines](https://wiki.antonischristofides.com/sops/production/development/third-party-libraries)
* [ ] I have removed all obsoleted code
