### PR TITLE
Fix error when aggregating too few values

### DIFF
--- a/enhydris/autoprocess/models.py
+++ b/enhydris/autoprocess/models.py
@@ -513,10 +513,10 @@ class Aggregation(AutoProcess):
         self.source_end_date = self.htimeseries.data.index[-1]
         try:
             regularized = self._regularize_time_series(self.htimeseries)
-        except RegularizeError as e:
+            aggregated = self._aggregate_time_series(regularized)
+        except (RegularizeError, ValueError) as e:
             logging.getLogger("enhydris.autoprocess").error(str(e))
             return HTimeseries()
-        aggregated = self._aggregate_time_series(regularized)
         return aggregated
 
     def _regularize_time_series(self, source_htimeseries):


### PR DESCRIPTION
An exception was occurring when there weren't enough source data for the new aggregated time series record. For example, if the aggregated day 2025-02-26 had already been calculated, and only 2025-02-27 00:10 had come in, the source time series had only one record that would correspond to the aggregated day 2025-02-27.

Except for the uncaught exception, this was not a problem, because eventually the aggregated value wouldn’t be calculated at all because of too few source values (however that check is made after inferring the source step). This might have an effect only in edge cases such as aggregating 30-minute to hourly, or when aggregating 10-minute to hourly allowing 4 or 5 missing values. Even in these cases, the effect would be to delay the aggregation for an hour or less (until more data comes in). Therefore, implementing a complicated solution where we could use more source records (that correspond to the previous aggregated record) to infer the step seems too much, and the solution we implemented was just to catch the exception and abandon the aggregation.

**Checklist**:

* [ ] All tests are passing
* [ ] I have added any necessary documentation and/or release notes
* [ ] I have followed the [commit message guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#committing-and-commit-messages) and the ["before submitting a pull request" guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#before-submitting-a-pull-request)
* [ ] If I introduced (or abolished) any third-party library, I will write a short paragraph in this PR [according to the guidelines](https://wiki.antonischristofides.com/sops/production/development/third-party-libraries)
* [ ] I have removed all obsoleted code
