### PR TITLE
Fix non-checking of station id in some API urls (fixes DEV-99)

### DIFF
--- a/enhydris/api/tests/test_views/test_timeseries.py
+++ b/enhydris/api/tests/test_views/test_timeseries.py
@@ -22,16 +22,19 @@ from enhydris.tests import TimeseriesDataMixin
 class Tsdata404TestCase(APITestCase):
     def setUp(self):
         self.station = baker.make(models.Station)
+        self.timeseries_group = baker.make(models.TimeseriesGroup, gentity=self.station)
 
     def test_get_nonexistent_timeseries(self):
         response = self.client.get(
-            "/api/stations/{}/timeseries/1234/data/".format(self.station.id)
+            f"/api/stations/{self.station.id}/timeseriesgroups/"
+            f"{self.timeseries_group.id}/timeseries/1234/data/"
         )
         self.assertEqual(response.status_code, 404)
 
     def test_post_nonexistent_timeseries(self):
         response = self.client.post(
-            "/api/stations/{}/timeseries/1234/data/".format(self.station.id)
+            f"/api/stations/{self.station.id}/timeseriesgroups/"
+            f"{self.timeseries_group.id}/timeseries/1235/data/"
         )
         self.assertEqual(response.status_code, 404)
 

--- a/enhydris/api/tests/test_views/test_timeseries.py
+++ b/enhydris/api/tests/test_views/test_timeseries.py
@@ -84,10 +84,14 @@ class GetDataTestCase(APITestCase, TimeseriesDataMixin):
     def setUpTestData(cls):
         cls.create_timeseries(publicly_available=True)
 
-    def _get_response(self, urlsuffix=""):
+    def _get_response(self, urlsuffix="", station_id=None, timeseries_group_id=None):
+        if station_id is None:
+            station_id = self.station.id
+        if timeseries_group_id is None:
+            timeseries_group_id = self.timeseries_group.id
         return self.client.get(
-            f"/api/stations/{self.station.id}/timeseriesgroups/"
-            f"{self.timeseries_group.id}/timeseries/{self.timeseries.id}/data/"
+            f"/api/stations/{station_id}/timeseriesgroups/"
+            f"{timeseries_group_id}/timeseries/{self.timeseries.id}/data/"
             f"{urlsuffix}"
         )
 
@@ -116,6 +120,14 @@ class GetDataTestCase(APITestCase, TimeseriesDataMixin):
             response.content.decode(),
             "2017-11-23 15:23,1.00,\r\n2018-11-24 23:00,2.00,\r\n",
         )
+
+    def test_wrong_station_id(self):
+        response = self._get_response(station_id=self.station.id + 1)
+        self.assertEqual(response.status_code, 404)
+
+    def test_wrong_timeseries_group_id(self):
+        response = self._get_response(timeseries_group_id=self.timeseries_group.id + 1)
+        self.assertEqual(response.status_code, 404)
 
 
 @override_settings(ENHYDRIS_AUTHENTICATION_REQUIRED=False)

--- a/enhydris/api/urls.py
+++ b/enhydris/api/urls.py
@@ -38,12 +38,6 @@ router.register(
     views.TimeseriesViewSet,
     "timeseries",
 )
-# The following is a backwards-compatible access point for time series,
-# /api/stations/20/timeseries/, e.g. /api/stations/20/timeseries/42/data/. Its purpose
-# is to enable older loggertodb versions to continue to work. Only the data/ and bottom/
-# endpoints (which are the only ones used by loggertodb) are supported; the rest might
-# not work.
-router.register(urlstart + r"timeseries", views.TimeseriesViewSet, "old-timeseries")
 
 router.register("gareas", views.GareaViewSet)
 router.register("organizations", views.OrganizationViewSet)

--- a/enhydris/api/views.py
+++ b/enhydris/api/views.py
@@ -182,18 +182,10 @@ class TimeseriesViewSet(ModelViewSet):
         return [x() for x in pc]
 
     def get_queryset(self):
-        try:
-            return models.Timeseries.objects.filter(
-                timeseries_group_id=self.kwargs["timeseries_group_id"]
-            )
-        except KeyError:
-            # Sometimes we know the station_id but not the timeseries_group_id. This
-            # happens in backwards-compatible URLs like /api/stations/1403/timeseries/.
-            # We don't unit-test this since it's deprecated and will be removed in a
-            # future version.
-            return models.Timeseries.objects.filter(
-                timeseries_group__gentity_id=self.kwargs["station_id"]
-            )
+        return models.Timeseries.objects.filter(
+            timeseries_group__gentity__id=self.kwargs["station_id"],
+            timeseries_group_id=self.kwargs["timeseries_group_id"],
+        )
 
     def create(self, request, *args, **kwargs):
         """Redefine create, checking permissions and gentity_id.

--- a/enhydris/api/views.py
+++ b/enhydris/api/views.py
@@ -299,7 +299,7 @@ class TimeseriesViewSet(ModelViewSet):
         return start_date, end_date
 
     def _get_data(self, request, pk, format=None):
-        timeseries = get_object_or_404(models.Timeseries, pk=int(pk))
+        timeseries = self.get_object()
         self.check_object_permissions(request, timeseries)
         start_date, end_date = self._get_date_bounds(request, timeseries)
         fmt_param = request.GET.get("fmt", "csv").lower()
@@ -333,7 +333,7 @@ class TimeseriesViewSet(ModelViewSet):
 
     def _post_data(self, request, pk, format=None):
         try:
-            atimeseries = get_object_or_404(models.Timeseries, pk=int(pk))
+            atimeseries = self.get_object()
             self.check_object_permissions(request, atimeseries)
             atimeseries.append_data(
                 StringIO(request.data["timeseries_records"]),

--- a/enhydris/tests/test_views/test_station.py
+++ b/enhydris/tests/test_views/test_station.py
@@ -248,15 +248,6 @@ class StationEditRedirectTestCase(TestCase):
         )
 
 
-@override_settings(ENHYDRIS_AUTHENTICATION_REQUIRED=False)
-class RedirectOldUrlsTestCase(TestCase):
-    def test_old_stations_url_redirects(self):
-        r = self.client.get("/stations/d/200348/")
-        self.assertRedirects(
-            r, "/stations/200348/", status_code=301, fetch_redirect_response=False
-        )
-
-
 @skipUnless(getattr(settings, "SELENIUM_WEBDRIVERS", False), "Selenium is unconfigured")
 @override_settings(ENHYDRIS_AUTHENTICATION_REQUIRED=False)
 class ListStationsVisibleOnMapTestCase(SeleniumTestCase):

--- a/enhydris/tests/test_views/test_timeseries_group.py
+++ b/enhydris/tests/test_views/test_timeseries_group.py
@@ -1,31 +1,6 @@
 from django.test import TestCase, override_settings
 
-from model_bakery import baker
-
-from enhydris.models import Timeseries
 from enhydris.tests import TimeseriesDataMixin
-
-
-@override_settings(ENHYDRIS_AUTHENTICATION_REQUIRED=False)
-class RedirectOldUrlsTestCase(TestCase):
-    def test_old_timeseries_url_redirects(self):
-        baker.make(
-            Timeseries,
-            id=1169,
-            timeseries_group__id=100174,
-            timeseries_group__gentity__id=200348,
-        )
-        r = self.client.get("/timeseries/d/1169/")
-        self.assertRedirects(
-            r,
-            "/stations/200348/timeseriesgroups/100174/",
-            status_code=301,
-            fetch_redirect_response=False,
-        )
-
-    def test_old_timeseries_url_for_nonexistent_timeseries_returns_404(self):
-        r = self.client.get("/timeseries/d/1169/")
-        self.assertEqual(r.status_code, 404)
 
 
 @override_settings(ENHYDRIS_AUTHENTICATION_REQUIRED=False)

--- a/enhydris/urls.py
+++ b/enhydris/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.urls import include, path
-from django.views.generic import RedirectView, View
+from django.views.generic import View
 
 from registration.backends.default.views import RegistrationView
 
@@ -33,11 +33,6 @@ urlpatterns = [
     path("grappelli/", include("grappelli.urls")),
     path("admin/", admin.site.urls),
     path("api/", include(enhydris_api_urls)),
-    path(
-        "stations/d/<int:pk>/",
-        RedirectView.as_view(pattern_name="station_detail", permanent=True),
-    ),
-    path("timeseries/d/<int:pk>/", views.OldTimeseriesDetailRedirectView.as_view()),
     path("_nested_admin/", include("nested_admin.urls")),
     *enhydris_telemetry_urlpatterns,
 ]

--- a/enhydris/views/__init__.py
+++ b/enhydris/views/__init__.py
@@ -1,12 +1,11 @@
 from .station import StationDetail, StationEdit, StationList
 from .timeseries import DownloadData
-from .timeseries_group import OldTimeseriesDetailRedirectView, TimeseriesGroupDetail
+from .timeseries_group import TimeseriesGroupDetail
 
 __all__ = (
     "StationDetail",
     "StationEdit",
     "StationList",
     "DownloadData",
-    "OldTimeseriesDetailRedirectView",
     "TimeseriesGroupDetail",
 )

--- a/enhydris/views/timeseries_group.py
+++ b/enhydris/views/timeseries_group.py
@@ -1,7 +1,3 @@
-from django.shortcuts import get_object_or_404
-from django.urls import reverse
-from django.views.generic import RedirectView
-
 from enhydris import forms, models
 
 from .utils import MapWithSingleStationBaseView
@@ -25,16 +21,3 @@ class TimeseriesGroupDetail(MapWithSingleStationBaseView):
             if self.request.user.has_perm("enhydris.view_timeseries_data", timeseries):
                 result.append(timeseries)
         return result
-
-
-class OldTimeseriesDetailRedirectView(RedirectView):
-    permanent = True
-
-    def get_redirect_url(self, *args, **kwargs):
-        timeseries = get_object_or_404(models.Timeseries, id=kwargs["pk"])
-        timeseries_group = timeseries.timeseries_group
-        gentity = timeseries_group.gentity
-        return reverse(
-            "timeseries_group_detail",
-            kwargs={"station_id": gentity.id, "pk": timeseries_group.id},
-        )


### PR DESCRIPTION
- **Remove backwards-compatible URLs**
- **Fix non-checking of station id in some API urls (fixes DEV-99)**

**Checklist**:

* [ ] All tests are passing
* [ ] I have added any necessary documentation and/or release notes
* [ ] I have followed the [commit message guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#committing-and-commit-messages) and the ["before submitting a pull request" guidelines](https://wiki.antonischristofides.com/en/sops/production/development/git-and-github#before-submitting-a-pull-request)
* [ ] If I introduced (or abolished) any third-party library, I will write a short paragraph in this PR [according to the guidelines](https://wiki.antonischristofides.com/sops/production/development/third-party-libraries)
* [ ] I have removed all obsoleted code
